### PR TITLE
Implement unique constraints without markers

### DIFF
--- a/djangaeidx.yaml
+++ b/djangaeidx.yaml
@@ -33,7 +33,6 @@ tests_specialindexesmodel:
   - item__regex__285b412d5a5d295c772b5c735b2b5d5c73285b412d5a5d295c772b
   - item__iregex__285b412d5a5d295c772b5c735b2b5d5c73285b412d5a5d295c772b
   - item__regex__5c2d546573745c2d
-  - item__iregex__5c2d546573745c2d
 tests_testfruit:
   color:
   - icontains

--- a/djangaeidx.yaml
+++ b/djangaeidx.yaml
@@ -33,6 +33,7 @@ tests_specialindexesmodel:
   - item__regex__285b412d5a5d295c772b5c735b2b5d5c73285b412d5a5d295c772b
   - item__iregex__285b412d5a5d295c772b5c735b2b5d5c73285b412d5a5d295c772b
   - item__regex__5c2d546573745c2d
+  - item__iregex__5c2d546573745c2d
 tests_testfruit:
   color:
   - icontains

--- a/gcloudc/db/backends/datastore/base.py
+++ b/gcloudc/db/backends/datastore/base.py
@@ -278,11 +278,9 @@ class DatabaseOperations(BaseDatabaseOperations):
             if [y for y in tables if x.startswith("_djangae_idx_{}".format(y))]
         ]
 
-        unique_markers_table = "uniquemarker"
-
         return [
             FlushCommand(table, self.connection)
-            for table in tables + additional_djangaeidx_tables + [unique_markers_table]
+            for table in tables + additional_djangaeidx_tables
         ]
 
     def prep_lookup_key(self, model, value, field):

--- a/gcloudc/db/backends/datastore/commands.py
+++ b/gcloudc/db/backends/datastore/commands.py
@@ -718,13 +718,13 @@ class InsertCommand(object):
                     if len(entities) > 1:
                         check_unique_markers_in_memory(self.model, entities)
 
-                    # even for bulk insert we also need to do the full check, to
-                    # query against unique markers created before the operation
-                    for entity, _ in entities:
-                        new_marker_keys.extend(
-                            # this is executed as an independent transaction
-                            acquire_unique_markers(self.model, entity, self.connection)
-                        )
+                    # # even for bulk insert we also need to do the full check, to
+                    # # query against unique markers created before the operation
+                    # for entity, _ in entities:
+                    #     new_marker_keys.extend(
+                    #         # this is executed as an independent transaction
+                    #         acquire_unique_markers(self.model, entity, self.connection)
+                    #     )
 
                 caching.add_entities_to_cache(
                     self.model,

--- a/gcloudc/db/backends/datastore/constraints.py
+++ b/gcloudc/db/backends/datastore/constraints.py
@@ -4,24 +4,18 @@ The Datastore does not provide database level constraints around uniqueness
 column, or a combination of columns).
 
 To mimic the ability to define these constraints using the Django API,
-we have implemented an approach where a Datastore Entity is used to represent
-each existing constraint. This uses a named key, which is generated from a
-combination of the django database model and the unique field/values.
+we have implemented an approach where, thanks to Cloud Firestore strong
+consistency we check unique constraints transactionally before any write
 
 This allows us to efficiently check for existing constraints before doing a put().
 """
-import datetime
 
-from . import transaction
-from .dbapi import DataError, IntegrityError
+from .dbapi import IntegrityError
 from .unique_utils import (
     unique_identifiers_from_entity,
     _has_enabled_constraints,
     _has_unique_constraints,
-    _get_kind_from_named_marker_key,
-    _get_unique_fields_from_named_marker_key,
 )
-from .utils import key_exists
 
 
 UNIQUE_MARKER_KIND = "uniquemarker"
@@ -41,137 +35,6 @@ def has_active_unique_constraints(model_or_instance):
 
     # does the object have unique constraints defined in the model definition
     return _has_unique_constraints(model_or_instance)
-
-
-# we need this transaction to be independent from any outer transaction,
-# to avoid eating away at the 500 entity write limit per transaction block
-@transaction.atomic(independent=True)
-def acquire_unique_markers(model, entity, connection):
-    """
-    Attempt to acquire all unique marker entities needed by the model definition
-    for the given entity property values. If a marker already exists and
-    references an existing entity (e.g. is not stale) we raise an IntegrityError.
-
-    Returns an iterable of all newly acquired keys, to support a rollback
-    in the outer transaction if required.
-    """
-
-    using = connection.alias
-    assert(using)
-
-    rpc = transaction._rpc(using)
-
-    def _put_unique_marker(unique_marker_entity):
-        """
-        Update a unique marker entity with some new properties and persist
-        the update/insertion into the datastore.
-        """
-        unique_marker_entity["updated_at"] = datetime.datetime.utcnow()
-        unique_marker_entity["instance"] = entity.key
-        # any put() is essentially async inside a transaction/batch operation
-        rpc.put(unique_marker_entity)
-
-        # update the in memory reference of any markers acquired
-        acquired_markers.append(unique_marker_entity.key)
-
-    acquired_markers = []
-
-    # get all the key objects we need to represent the entities we put
-    unique_marker_keys = _get_unique_marker_keys_for_entity(model, entity, connection, refetch=False)
-
-    # we can now pass these to the client to fetch the existing unique markers
-    # (note that the raw datastore API get has an odd signature, where you
-    # need to pass a list kwarg to explicity identify which ones are missing)
-    missing_markers = []
-    existing_unique_markers = rpc.get(unique_marker_keys, missing=missing_markers)
-
-    # handle the markers we know don't exist yet - these can be a straight put()
-    for missing_entity in missing_markers:
-        _put_unique_marker(missing_entity)
-
-    # for the remaining entities, decide what action to take...
-    for existing_marker in existing_unique_markers:
-        put_unique_marker = False
-
-        # if there is a stale unique marker but it doesn't have an instance
-        # associated with it, we can grab it and reference our entity
-        if existing_marker["instance"] is None:
-            put_unique_marker = True
-
-        # if any of unique markers exist but reference a different underlying
-        # entity (which isn't stale / deleted now), we need to raise an error
-        # as the unique constraint is already satisfied
-        elif existing_marker["instance"] != entity.key:
-
-            # double check the instance isn't stale / deleted now
-            if key_exists(using, existing_marker["instance"]):
-
-                # we can reverse parse the named key to find the fields
-                # which have failed the unique constraint check
-                table_name = _get_kind_from_named_marker_key(existing_marker.key)
-                unique_fields = _get_unique_fields_from_named_marker_key(existing_marker.key)
-                raise IntegrityError(CONSTRAINT_VIOLATION_MSG.format(table_name, ", ".join(unique_fields)))
-
-            # if the referened entity doesn't exist, we can claim the marker
-            else:
-                put_unique_marker = True
-
-        # update the unique marker entity
-        if put_unique_marker:
-            _put_unique_marker(existing_marker)
-
-    # we return all the keys of markers we have touched to the caller, to handle
-    # cases where the final put() of the actual entity fails, allowing us to
-    # cleanup these markers / avoid leaving stale entity references
-    return acquired_markers
-
-
-@transaction.atomic(independent=True)
-def delete_unique_markers(unique_marker_keys, connection):
-    """
-    Thin wrapper around a RPC delete operation on an iterable of keys inside
-    an independent transaction block.
-
-    If you don't know what unique markers you need to delete, you can use
-    `delete_unique_markers_for_entity` which calculates the named keys
-    from the entity values.
-    """
-    transaction._rpc(connection.alias).delete(unique_marker_keys)
-
-
-@transaction.atomic()
-def delete_unique_markers_for_entity(model, entity, connection, refetch=True):
-    """
-    Delete all UniqueMarkers which reference a given entity.
-
-    Rather than do a query to find all references, we can grab all the
-    UniqueMarker entities by key for a small performance win.
-    """
-    unique_marker_keys = _get_unique_marker_keys_for_entity(model, entity, connection, refetch=refetch)
-    transaction._rpc(connection.alias).delete(unique_marker_keys)
-
-
-@transaction.atomic()
-def _get_unique_marker_keys_for_entity(model, entity, connection, refetch=True):
-    """
-    This function encapsulates a common pattern of refetching the given entity,
-    generating the named key string given the model unique constraints /
-    corresponding entity property values, and then fetching these entities
-    using the datastore client.
-    """
-    # if we refetch an object which has just been put() in the same transaction
-    # it won't be found, so we need to support avoiding this...
-    if refetch:
-        entity = transaction._rpc(connection).get(entity.key)
-        if entity is None:
-            # TODO what would be the best exception to raise if the entity is gone
-            raise DataError("Entity no longer exists")
-
-    marker_key_values = unique_identifiers_from_entity(model, entity)
-    return [
-        connection.connection.gclient.key(UNIQUE_MARKER_KIND, identifier, namespace=connection.namespace)
-        for identifier in marker_key_values
-    ]
 
 
 def check_unique_markers_in_memory(model, entities):

--- a/gcloudc/db/backends/datastore/transaction.py
+++ b/gcloudc/db/backends/datastore/transaction.py
@@ -360,7 +360,7 @@ class AtomicDecorator(context_decorator.ContextDecorator):
                 else:
                     try:
                         transaction._datastore_transaction.commit()
-                    except exceptions.GoogleAPIError:
+                    except exceptions.GoogleCloudError:
                         raise TransactionFailedError()
         finally:
             if isinstance(transaction, (IndependentTransaction, NormalTransaction)):

--- a/gcloudc/db/backends/datastore/unique_utils.py
+++ b/gcloudc/db/backends/datastore/unique_utils.py
@@ -146,22 +146,6 @@ def unique_identifiers_from_entity(model, entity, ignore_pk=True, ignore_null_va
     return identifiers
 
 
-def _get_kind_from_named_marker_key(unique_marker_key):
-    """
-    Extracts and returns the table name prefix from a UniqueMarker named key.
-    """
-    return unique_marker_key.name.split("|")[0]
-
-
-def _get_unique_fields_from_named_marker_key(unique_marker_key):
-    """
-    Extracts and returns all the unique field names from a UniqueMarker
-    named key.
-    """
-    fields_and_values = unique_marker_key.name.split("|")[1:]
-    return [unique_field_name.split(":")[0] for unique_field_name in fields_and_values]
-
-
 def _unique_combinations(model, ignore_pk=False):
     """
     Returns an iterable of iterables to represent all the unique constraints

--- a/gcloudc/tests/test_unique_constraints.py
+++ b/gcloudc/tests/test_unique_constraints.py
@@ -37,25 +37,25 @@ class TestUniqueConstraints(TestCase):
         If a subsequent insert is attempted, these should be compared to
         enforce a constraint similar to SQL.
         """
-        user = TestUser.objects.create(username="tommyd", first_name="Tommy", second_name="Doherty")
-
-        # unique_markers = get_kind_query("uniquemarker", keys_only=True)
-        # self.assertEqual(len(unique_markers), 2)
+        TestUser.objects.create(username="tommyd", first_name="Tommy", second_name="Shelby")
 
         # attempt to create another entity which violates one of the constraints
         with self.assertRaises(IntegrityError):
-            TestUser.objects.create(username="thetommyd", first_name="Tommy", second_name="Doherty")
+            TestUser.objects.create(username="tommyd", first_name="Tommy", second_name="Doherty")
 
-        # # there should still only be two unique markers, both referencing
-        # # the original entity
-        # unique_markers = get_kind_query("uniquemarker", keys_only=False)
-        # self.assertEqual(len(unique_markers), 2)
-        # for marker in unique_markers:
-        #     key = Key(
-        #         TestUser._meta.db_table, user.pk, project="test",
-        #         namespace=connection.settings_dict["NAMESPACE"]
-        #     )
-        #     self.assertEqual(marker["instance"], key)
+    def test_insert_unique_together(self):
+        """
+        Assert that when creating a new instance, unique markers are also
+        created to reflect the constraints defined on the model.
+
+        If a subsequent insert is attempted, these should be compared to
+        enforce a constraint similar to SQL.
+        """
+        TestUser.objects.create(username="tommyd", first_name="Tommy", second_name="Doherty")
+
+        # attempt to create another entity which violates a unique_together constraint
+        with self.assertRaises(IntegrityError):
+            TestUser.objects.create(username="thetommyd", first_name="Tommy", second_name="Doherty")
 
     def test_bulk_insert(self):
         """

--- a/gcloudc/tests/test_unique_constraints.py
+++ b/gcloudc/tests/test_unique_constraints.py
@@ -39,23 +39,23 @@ class TestUniqueConstraints(TestCase):
         """
         user = TestUser.objects.create(username="tommyd", first_name="Tommy", second_name="Doherty")
 
-        unique_markers = get_kind_query("uniquemarker", keys_only=True)
-        self.assertEqual(len(unique_markers), 2)
+        # unique_markers = get_kind_query("uniquemarker", keys_only=True)
+        # self.assertEqual(len(unique_markers), 2)
 
         # attempt to create another entity which violates one of the constraints
         with self.assertRaises(IntegrityError):
             TestUser.objects.create(username="thetommyd", first_name="Tommy", second_name="Doherty")
 
-        # there should still only be two unique markers, both referencing
-        # the original entity
-        unique_markers = get_kind_query("uniquemarker", keys_only=False)
-        self.assertEqual(len(unique_markers), 2)
-        for marker in unique_markers:
-            key = Key(
-                TestUser._meta.db_table, user.pk, project="test",
-                namespace=connection.settings_dict["NAMESPACE"]
-            )
-            self.assertEqual(marker["instance"], key)
+        # # there should still only be two unique markers, both referencing
+        # # the original entity
+        # unique_markers = get_kind_query("uniquemarker", keys_only=False)
+        # self.assertEqual(len(unique_markers), 2)
+        # for marker in unique_markers:
+        #     key = Key(
+        #         TestUser._meta.db_table, user.pk, project="test",
+        #         namespace=connection.settings_dict["NAMESPACE"]
+        #     )
+        #     self.assertEqual(marker["instance"], key)
 
     def test_bulk_insert(self):
         """

--- a/gcloudc/tests/test_unique_constraints.py
+++ b/gcloudc/tests/test_unique_constraints.py
@@ -149,7 +149,7 @@ class TestUniqueConstraints(TestCase):
         user = TestUserTwo.objects.create(username="AshtonGateEight")
 
         with sleuth.detonate("gcloudc.db.backends.datastore.transaction.Transaction.put", TransactionFailedError):
-            with self.assertRaises(TransactionFailedError):
+            with self.assertRaises(IntegrityError):
                 user.username = "Red Army"
                 user.save()
 


### PR DESCRIPTION
As per discussion with @Kazade, I've tried to reimplement the unique constraints _without_ any of the extra marker entities. As part of this I've deleted quite a few tests that were specifically looking at the old marker implementation, and discovered a [potential bug](https://github.com/googleapis/google-cloud-python/issues/9921) in the datastore emulator, which seems to be making us hit the 25 entity group limit despite that being mentioned as a no longer existing limit in Cloud Firestore in Datastore mode.

I did not touch any of the UniqueMixin logic (mostly because I'm not 100% sure of what it does/how it should work) and also because tests were already failing for that :) 

